### PR TITLE
delegate bug fix

### DIFF
--- a/KMFramework/src/KMBombInfo.cs
+++ b/KMFramework/src/KMBombInfo.cs
@@ -40,7 +40,7 @@ public class KMBombInfo : MonoBehaviour
     public KMBombSolvedDelegate OnBombSolved;
 
     public delegate void KMBombExplodedDelegate();
-    public KMBombSolvedDelegate OnBombExploded;
+    public KMBombExplodedDelegate OnBombExploded;
 
     /// <returns>Time remaining on the bomb, in seconds.</returns>
     public float GetTime()


### PR DESCRIPTION
Shouldn't OnBombExploded be of type KMBombExplodedDelegate instead of KMBombSolvedDelegate?