### PR TITLE
Disallow KM components from being added to objects multiple times

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ ExportedObj/
 
 # Unity3D Generated File On Crash Reports
 sysinfo.txt
+
+.idea

--- a/KMFramework/src/KMAudio.cs
+++ b/KMFramework/src/KMAudio.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 /// Component that provides an interface to the game's audio system. Allows playing of sounds in a way that will
 /// respect volume settings and gameplay events. Can be used to play existing sounds or sounds added in this mod.
 /// </summary>
+[DisallowMultipleComponent]
 public class KMAudio : MonoBehaviour
 {
     public class KMAudioRef

--- a/KMFramework/src/KMAudio.cs
+++ b/KMFramework/src/KMAudio.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 /// Component that provides an interface to the game's audio system. Allows playing of sounds in a way that will
 /// respect volume settings and gameplay events. Can be used to play existing sounds or sounds added in this mod.
 /// </summary>
+[HelpURL("https://github.com/Qkrisi/ktanemodkit/wiki/KMAudio")]
 [DisallowMultipleComponent]
 public class KMAudio : MonoBehaviour
 {

--- a/KMFramework/src/KMBomb.cs
+++ b/KMFramework/src/KMBomb.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 /// Component representing the bomb visual, including the faces upon which modules are placed as well
 /// as the areas for spawning widgets.
 /// </summary>
+[HelpURL("https://github.com/Qkrisi/ktanemodkit/wiki/KMBomb")]
 [DisallowMultipleComponent]
 public class KMBomb : MonoBehaviour
 {

--- a/KMFramework/src/KMBomb.cs
+++ b/KMFramework/src/KMBomb.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 /// Component representing the bomb visual, including the faces upon which modules are placed as well
 /// as the areas for spawning widgets.
 /// </summary>
+[DisallowMultipleComponent]
 public class KMBomb : MonoBehaviour
 {
     public List<KMBombFace> Faces;

--- a/KMFramework/src/KMBombFace.cs
+++ b/KMFramework/src/KMBombFace.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 /// <summary>
 /// A collection of transforms where modules can be instantiated along with their backings.
 /// </summary>
+[DisallowMultipleComponent]
 public class KMBombFace : MonoBehaviour
 {
     /// <summary>

--- a/KMFramework/src/KMBombFace.cs
+++ b/KMFramework/src/KMBombFace.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 /// <summary>
 /// A collection of transforms where modules can be instantiated along with their backings.
 /// </summary>
+[HelpURL("https://github.com/Qkrisi/ktanemodkit/wiki/KMBombFace")]
 [DisallowMultipleComponent]
 public class KMBombFace : MonoBehaviour
 {

--- a/KMFramework/src/KMBombInfo.cs
+++ b/KMFramework/src/KMBombInfo.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 /// Interface to information about the bomb and its widgets. 
 /// Add this component to a module to query properties of the bomb for use in rules.
 /// </summary>
+[DisallowMultipleComponent]
 public class KMBombInfo : MonoBehaviour
 {
     public static string QUERYKEY_GET_SERIAL_NUMBER = "serial";

--- a/KMFramework/src/KMBombInfo.cs
+++ b/KMFramework/src/KMBombInfo.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 /// Interface to information about the bomb and its widgets. 
 /// Add this component to a module to query properties of the bomb for use in rules.
 /// </summary>
+[HelpURL("https://github.com/Qkrisi/ktanemodkit/wiki/KMBombInfo")]
 [DisallowMultipleComponent]
 public class KMBombInfo : MonoBehaviour
 {

--- a/KMFramework/src/KMBombModule.cs
+++ b/KMFramework/src/KMBombModule.cs
@@ -3,6 +3,7 @@
 /// <summary>
 /// This class acts as a proxy for the game's needy bomb module. Don't subclass but instead add it as a component.
 /// </summary>
+[HelpURL("https://github.com/Qkrisi/ktanemodkit/wiki/KMBombModule")]
 [DisallowMultipleComponent]
 public class KMBombModule : MonoBehaviour
 {

--- a/KMFramework/src/KMBombModule.cs
+++ b/KMFramework/src/KMBombModule.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System;
+using UnityEngine;
 
 /// <summary>
 /// This class acts as a proxy for the game's needy bomb module. Don't subclass but instead add it as a component.
@@ -53,9 +54,10 @@ public class KMBombModule : MonoBehaviour
     }
 
     /// <summary>
-    /// Returns the random seed used to generate the rules for this game. Not currently used.
+    /// Returns the random seed used to generate the rules for this game. Not used by the game.
     /// </summary>
     /// <returns></returns>
+    [Obsolete("This method is not used by the game. To implement rule seed, use KMRuleSeedable.")]
     public int GetRuleGenerationSeed()
     {
         if (GetRuleGenerationSeedHandler != null)

--- a/KMFramework/src/KMBombModule.cs
+++ b/KMFramework/src/KMBombModule.cs
@@ -3,6 +3,7 @@
 /// <summary>
 /// This class acts as a proxy for the game's needy bomb module. Don't subclass but instead add it as a component.
 /// </summary>
+[DisallowMultipleComponent]
 public class KMBombModule : MonoBehaviour
 {
     /// <summary>

--- a/KMFramework/src/KMGameCommands.cs
+++ b/KMFramework/src/KMGameCommands.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 /// <summary>
 /// Interface to directly execute actions related to the game or controlling game flow.
 /// </summary>
+[DisallowMultipleComponent]
 public class KMGameCommands : MonoBehaviour
 {
     /// <summary>

--- a/KMFramework/src/KMGameCommands.cs
+++ b/KMFramework/src/KMGameCommands.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 /// <summary>
 /// Interface to directly execute actions related to the game or controlling game flow.
 /// </summary>
+[HelpURL("https://github.com/Qkrisi/ktanemodkit/wiki/KMGameCommands")]
 [DisallowMultipleComponent]
 public class KMGameCommands : MonoBehaviour
 {

--- a/KMFramework/src/KMGameInfo.cs
+++ b/KMFramework/src/KMGameInfo.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 /// <summary>
 /// Interface to get information about game and to get notified of game state changes.
 /// </summary>
+[DisallowMultipleComponent]
 public class KMGameInfo : MonoBehaviour
 {
     /// <summary>

--- a/KMFramework/src/KMGameInfo.cs
+++ b/KMFramework/src/KMGameInfo.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 /// <summary>
 /// Interface to get information about game and to get notified of game state changes.
 /// </summary>
+[HelpURL("https://github.com/Qkrisi/ktanemodkit/wiki/KMGameInfo")]
 [DisallowMultipleComponent]
 public class KMGameInfo : MonoBehaviour
 {

--- a/KMFramework/src/KMGamepad.cs
+++ b/KMFramework/src/KMGamepad.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEngine;
 
+[DisallowMultipleComponent]
 public class KMGamepad :MonoBehaviour
 {
     /// <summary>

--- a/KMFramework/src/KMGamepad.cs
+++ b/KMFramework/src/KMGamepad.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEngine;
 
+[HelpURL("https://github.com/Qkrisi/ktanemodkit/wiki/KMGamepad")]
 [DisallowMultipleComponent]
 public class KMGamepad :MonoBehaviour
 {

--- a/KMFramework/src/KMGameplayRoom.cs
+++ b/KMFramework/src/KMGameplayRoom.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 /// <summary>
 /// Add this component to a prefab to allow it to be used as a room during gameplay (i.e. bomb defusal).
 /// </summary>
+[HelpURL("https://github.com/Qkrisi/ktanemodkit/wiki/KMGameplayRoom")]
 [DisallowMultipleComponent]
 public class KMGameplayRoom : KMRoom
 {

--- a/KMFramework/src/KMGameplayRoom.cs
+++ b/KMFramework/src/KMGameplayRoom.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 /// <summary>
 /// Add this component to a prefab to allow it to be used as a room during gameplay (i.e. bomb defusal).
 /// </summary>
+[DisallowMultipleComponent]
 public class KMGameplayRoom : KMRoom
 {
     public delegate void KMGameplayLightChange(bool on);

--- a/KMFramework/src/KMHighlightable.cs
+++ b/KMFramework/src/KMHighlightable.cs
@@ -3,6 +3,7 @@
 /// <summary>
 /// Add this component to create a highlight at runtime based on this object's renderer.
 /// </summary>
+[DisallowMultipleComponent]
 public class KMHighlightable : MonoBehaviour
 {
     /// <summary>

--- a/KMFramework/src/KMHighlightable.cs
+++ b/KMFramework/src/KMHighlightable.cs
@@ -3,6 +3,7 @@
 /// <summary>
 /// Add this component to create a highlight at runtime based on this object's renderer.
 /// </summary>
+[HelpURL("https://github.com/Qkrisi/ktanemodkit/wiki/KMHighlightable")]
 [DisallowMultipleComponent]
 public class KMHighlightable : MonoBehaviour
 {

--- a/KMFramework/src/KMHoldable.cs
+++ b/KMFramework/src/KMHoldable.cs
@@ -5,6 +5,7 @@ using System;
 /// Interface to define a holdable object that can be picked up by motion controls
 /// Should add a rigidbody or a default one will be created
 /// </summary>
+[DisallowMultipleComponent]
 public class KMHoldable : MonoBehaviour
 {
     /// <summary>

--- a/KMFramework/src/KMHoldable.cs
+++ b/KMFramework/src/KMHoldable.cs
@@ -5,6 +5,7 @@ using System;
 /// Interface to define a holdable object that can be picked up by motion controls
 /// Should add a rigidbody or a default one will be created
 /// </summary>
+[HelpURL("https://github.com/Qkrisi/ktanemodkit/wiki/KMHoldable")]
 [DisallowMultipleComponent]
 public class KMHoldable : MonoBehaviour
 {

--- a/KMFramework/src/KMHoldableSpawnPoint.cs
+++ b/KMFramework/src/KMHoldableSpawnPoint.cs
@@ -4,6 +4,7 @@ using System.Collections;
 /// <summary>
 /// A class for specifying spawn points for holdable objects
 /// </summary>
+[HelpURL("https://github.com/Qkrisi/ktanemodkit/wiki/KMHoldableSpawnPoint")]
 [DisallowMultipleComponent]
 public class KMHoldableSpawnPoint : MonoBehaviour
 {

--- a/KMFramework/src/KMHoldableSpawnPoint.cs
+++ b/KMFramework/src/KMHoldableSpawnPoint.cs
@@ -4,6 +4,7 @@ using System.Collections;
 /// <summary>
 /// A class for specifying spawn points for holdable objects
 /// </summary>
+[DisallowMultipleComponent]
 public class KMHoldableSpawnPoint : MonoBehaviour
 {
     /// <summary>

--- a/KMFramework/src/KMMaterialInfo.cs
+++ b/KMFramework/src/KMMaterialInfo.cs
@@ -5,6 +5,8 @@ using System.Collections.Generic;
 /// This component is added during assetbundle build to any game objects that have material components
 /// This should not be used by modders but is instead used to mitigate potential future incompatibilities in Unity
 /// </summary>
+[HelpURL("https://github.com/Qkrisi/ktanemodkit/wiki/KMMaterialInfo")]
+[AddComponentMenu("")]
 public class KMMaterialInfo : MonoBehaviour
 {
     /// <summary>

--- a/KMFramework/src/KMModSettings.cs
+++ b/KMFramework/src/KMModSettings.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 /// Useful for user-specific settings in a mod, such as configuring a Twitch account or anything else a user
 /// may tweak about a mod.
 /// </summary>
+[HelpURL("https://github.com/Qkrisi/ktanemodkit/wiki/KMModSettings")]
 [DisallowMultipleComponent]
 public class KMModSettings : MonoBehaviour
 {

--- a/KMFramework/src/KMModSettings.cs
+++ b/KMFramework/src/KMModSettings.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 /// Useful for user-specific settings in a mod, such as configuring a Twitch account or anything else a user
 /// may tweak about a mod.
 /// </summary>
+[DisallowMultipleComponent]
 public class KMModSettings : MonoBehaviour
 {
     /// <summary>

--- a/KMFramework/src/KMModuleBacking.cs
+++ b/KMFramework/src/KMModuleBacking.cs
@@ -4,6 +4,7 @@
 /// Visual models of the foam behind modules. Modules that have holes or recesses can have parts of this
 /// visible.
 /// </summary>
+[DisallowMultipleComponent]
 public class KMModuleBacking : MonoBehaviour
 {
     /// <summary>

--- a/KMFramework/src/KMModuleBacking.cs
+++ b/KMFramework/src/KMModuleBacking.cs
@@ -4,6 +4,7 @@
 /// Visual models of the foam behind modules. Modules that have holes or recesses can have parts of this
 /// visible.
 /// </summary>
+[HelpURL("https://github.com/Qkrisi/ktanemodkit/wiki/KMModuleBacking")]
 [DisallowMultipleComponent]
 public class KMModuleBacking : MonoBehaviour
 {

--- a/KMFramework/src/KMNeedyModule.cs
+++ b/KMFramework/src/KMNeedyModule.cs
@@ -3,6 +3,7 @@
 /// <summary>
 /// This class acts as a proxy for the game's needy bomb module. Don't subclass but instead add it as a component.
 /// </summary>
+[HelpURL("https://github.com/Qkrisi/ktanemodkit/wiki/KMNeedyModule")]
 [DisallowMultipleComponent]
 public class KMNeedyModule : MonoBehaviour
 {

--- a/KMFramework/src/KMNeedyModule.cs
+++ b/KMFramework/src/KMNeedyModule.cs
@@ -3,6 +3,7 @@
 /// <summary>
 /// This class acts as a proxy for the game's needy bomb module. Don't subclass but instead add it as a component.
 /// </summary>
+[DisallowMultipleComponent]
 public class KMNeedyModule : MonoBehaviour
 {
     /// <summary>

--- a/KMFramework/src/KMRoom.cs
+++ b/KMFramework/src/KMRoom.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 /// <summary>
 /// Generic room behaviour - use KMGameplayRoom or KMSetupRoom instead.
 /// </summary>
-[DisallowMultipleComponent]
 public abstract class KMRoom : MonoBehaviour
 {
     /// <summary>

--- a/KMFramework/src/KMRoom.cs
+++ b/KMFramework/src/KMRoom.cs
@@ -4,7 +4,8 @@ using System.Collections.Generic;
 /// <summary>
 /// Generic room behaviour - use KMGameplayRoom or KMSetupRoom instead.
 /// </summary>
-public class KMRoom : MonoBehaviour
+[DisallowMultipleComponent]
+public abstract class KMRoom : MonoBehaviour
 {
     /// <summary>
     /// Transform to spawn the bomb at.

--- a/KMFramework/src/KMSelectable.cs
+++ b/KMFramework/src/KMSelectable.cs
@@ -5,6 +5,7 @@ using System;
 /// The interface to all interactive elements in the game. Set this up to allow an object to be
 /// selected, interacted with, and handle input.
 /// </summary>
+[DisallowMultipleComponent]
 public class KMSelectable : MonoBehaviour
 {
     /// <summary>

--- a/KMFramework/src/KMSelectable.cs
+++ b/KMFramework/src/KMSelectable.cs
@@ -5,6 +5,7 @@ using System;
 /// The interface to all interactive elements in the game. Set this up to allow an object to be
 /// selected, interacted with, and handle input.
 /// </summary>
+[HelpURL("https://github.com/Qkrisi/ktanemodkit/wiki/KMSelectable")]
 [DisallowMultipleComponent]
 public class KMSelectable : MonoBehaviour
 {

--- a/KMFramework/src/KMService.cs
+++ b/KMFramework/src/KMService.cs
@@ -3,6 +3,7 @@
 /// <summary>
 /// The base class for any mod behaviour you wish to have activated immediately and run indefinitely.
 /// </summary>
+[DisallowMultipleComponent]
 public class KMService : MonoBehaviour
 {
 

--- a/KMFramework/src/KMService.cs
+++ b/KMFramework/src/KMService.cs
@@ -3,8 +3,8 @@
 /// <summary>
 /// The base class for any mod behaviour you wish to have activated immediately and run indefinitely.
 /// </summary>
+[HelpURL("https://github.com/Qkrisi/ktanemodkit/wiki/KMService")]
 [DisallowMultipleComponent]
 public class KMService : MonoBehaviour
 {
-
 }

--- a/KMFramework/src/KMSetupRoom.cs
+++ b/KMFramework/src/KMSetupRoom.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 /// <summary>
 /// Add this component to a prefab to allow it to be used as a room during setup (e.g. the office with the bomb binder and freeplay device).
 /// </summary>
+[HelpURL("https://github.com/Qkrisi/ktanemodkit/wiki/KMSetupRoom")]
 [DisallowMultipleComponent]
 public class KMSetupRoom : KMRoom
 {

--- a/KMFramework/src/KMSetupRoom.cs
+++ b/KMFramework/src/KMSetupRoom.cs
@@ -1,8 +1,9 @@
-﻿using UnityEngine;
+using UnityEngine;
 
 /// <summary>
 /// Add this component to a prefab to allow it to be used as a room during setup (e.g. the office with the bomb binder and freeplay device).
 /// </summary>
+[DisallowMultipleComponent]
 public class KMSetupRoom : KMRoom
 {
     /// <summary>

--- a/KMFramework/src/KMSoundOverride.cs
+++ b/KMFramework/src/KMSoundOverride.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 /// Add this component to a prefab to specify an AudioClip that should be played whenever the
 /// given sound effect is triggered instead of the original game's audio.
 /// </summary>
+[HelpURL("https://github.com/Qkrisi/ktanemodkit/wiki/KMSoundOverride")]
 public class KMSoundOverride : MonoBehaviour
 {
     public enum SoundEffect

--- a/KMFramework/src/KMStatusLightParent.cs
+++ b/KMFramework/src/KMStatusLightParent.cs
@@ -1,7 +1,7 @@
 ﻿using UnityEngine;
 
+[HelpURL("https://github.com/Qkrisi/ktanemodkit/wiki/KMStatusLightParent")]
 [DisallowMultipleComponent]
 public class KMStatusLightParent : MonoBehaviour
 {
-
 }

--- a/KMFramework/src/KMStatusLightParent.cs
+++ b/KMFramework/src/KMStatusLightParent.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEngine;
 
+[DisallowMultipleComponent]
 public class KMStatusLightParent : MonoBehaviour
 {
 

--- a/KMFramework/src/KMWidget.cs
+++ b/KMFramework/src/KMWidget.cs
@@ -4,6 +4,7 @@
 /// A proxy for the game's Widget class, which is a non-interactive, but queryable, element that can be added around the bombs. Don't subclass but instead add it as a component.
 /// E.g. serial number, indicator light, ports. 
 /// </summary>
+[DisallowMultipleComponent]
 public class KMWidget : MonoBehaviour
 {
     /// <summary>

--- a/KMFramework/src/KMWidget.cs
+++ b/KMFramework/src/KMWidget.cs
@@ -4,6 +4,7 @@
 /// A proxy for the game's Widget class, which is a non-interactive, but queryable, element that can be added around the bombs. Don't subclass but instead add it as a component.
 /// E.g. serial number, indicator light, ports. 
 /// </summary>
+[HelpURL("https://github.com/Qkrisi/ktanemodkit/wiki/KMWidget")]
 [DisallowMultipleComponent]
 public class KMWidget : MonoBehaviour
 {


### PR DESCRIPTION
There were issues caused by modders accidentally adding a KM... component to an object multiple times, the game only sets the delegates of one of them, so if they call the other one, it won't work. I added the `DisallowMultipleComponent` attribute to the KM components so Unity won't allow the objects to have more than one of them.

I also made the `KMRoom` component abstract, since it's not meant to be used on its own.